### PR TITLE
Fix typedoc link module syntax

### DIFF
--- a/src/animationInputMappers.ts
+++ b/src/animationInputMappers.ts
@@ -79,7 +79,7 @@ export const toToggleAnimations = (togglingOn: AnimationInput): AnimationsByName
 /**
  * Helper to create AnimationsByName for a SimpleTransition animation
  *
- * See {@link hooks.useSimpleTransitionState!default}
+ * See {@link hooks.useSimpleTransitionState}
  *
  * @param transition
  */

--- a/src/components/ControlledAnimated.tsx
+++ b/src/components/ControlledAnimated.tsx
@@ -14,7 +14,7 @@ export type ControlledAnimatedProps<A extends string, T extends HTMLIntrinsics =
     /**
      * Callback to be called when the animation is finished() or is interrupted by a new animationName
      * @param completedAnimationName the animation state that is ending
-     * @param webAnimation the {@link Animation} that is ending or null if the animation could not be started
+     * @param webAnimation the Web API Animation that is ending or null if the animation could not be started
      */
     onAnimationEnd?: (completedAnimationName: A, webAnimation: Animation | null) => void;
 } & AnimatedProps<A, T>;
@@ -61,7 +61,7 @@ const controlledAnimated = <A extends string, T extends HTMLIntrinsics = "div">(
 /**
  * An Animated component that is controlled by the currentAnimation prop
  * The component may be changed to a different HTML tag delegate via the as prop
- * May accept a ref to forward to the HTML tag delegate, though there is no need to pass an AnimatedRef (see @link Animated)
+ * May accept a ref to forward to the HTML tag delegate, though there is no need to pass an AnimatedRef (see @link components.Animated)
  * 
  * This component is useful for synchronizing animations with other animated elements
  * @typeParam A the accepted animation names

--- a/src/components/HoverAnimated.tsx
+++ b/src/components/HoverAnimated.tsx
@@ -23,7 +23,7 @@ function hoverAnimated<A extends string = never, T extends HTMLIntrinsics = "div
 /**
  * An Animated component that will track hover (via mouseenter/mouseleave listeners) and change animations to the corresponding hover state
  * May accept a ref to forward to the HTML tag delegate
- * @typeParam A the additional animation names; default = never makes the default animation names exactly {@link HoverAnimations}
+ * @typeParam A the additional animation names; default = never makes the default animation names exactly {@link components.HoverAnimations}
  * @typeParam T the HTML Tag delegate
  */
 const HoverAnimated = React.forwardRef(hoverAnimated) as <A extends string = never, T extends HTMLIntrinsics = "div">(

--- a/src/hooks/useAnimatedRef.ts
+++ b/src/hooks/useAnimatedRef.ts
@@ -22,7 +22,7 @@ export function isAnimatedRef<E>(ref: Ref<E> | null | undefined): ref is Animate
 /**
  * Low-level hook to useRef that will animate the ref'd HTML element with the given currentAnimation name
  *
- * Expects the AnimationsByName<A> to be serialized as a JSON string in the data-animations attribute on the element - see {@link ControlledAnimated!}
+ * Expects the AnimationsByName<A> to be serialized as a JSON string in the data-animations attribute on the element - see {@link components.ControlledAnimated}
  *
  * Note: will interrupt and play a new animation if the animations stored at data-animations change and the Component using this hook is rerendered
  *

--- a/typedocs/AnimationInput.NormalizedAnimation.md
+++ b/typedocs/AnimationInput.NormalizedAnimation.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[AnimationInput.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L6)
+[AnimationInput.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L6)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L7)
+[AnimationInput.ts:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L7)

--- a/typedocs/AnimationInput.NormalizedAnimation.md
+++ b/typedocs/AnimationInput.NormalizedAnimation.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[AnimationInput.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L6)
+[AnimationInput.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L6)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L7)
+[AnimationInput.ts:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L7)

--- a/typedocs/AnimationInput.md
+++ b/typedocs/AnimationInput.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[AnimationInput.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L10)
+[AnimationInput.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L10)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:1](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L1)
+[AnimationInput.ts:1](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L1)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L29)
+[AnimationInput.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L29)
 
 ## Functions
 
@@ -70,4 +70,4 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/AnimationInput.ts#L18)
+[AnimationInput.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L18)

--- a/typedocs/AnimationInput.md
+++ b/typedocs/AnimationInput.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[AnimationInput.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L10)
+[AnimationInput.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L10)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:1](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L1)
+[AnimationInput.ts:1](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L1)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L29)
+[AnimationInput.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L29)
 
 ## Functions
 
@@ -70,4 +70,4 @@ ___
 
 #### Defined in
 
-[AnimationInput.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/AnimationInput.ts#L18)
+[AnimationInput.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/AnimationInput.ts#L18)

--- a/typedocs/animationInputMappers.md
+++ b/typedocs/animationInputMappers.md
@@ -34,7 +34,7 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:20](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L20)
+[animationInputMappers.ts:20](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/animationInputMappers.ts#L20)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 Helper to create AnimationsByName for a SimpleTransition animation
 
-See hooks.useSimpleTransitionState!default
+See [useSimpleTransitionState](../wiki/hooks#usesimpletransitionstate)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ See hooks.useSimpleTransitionState!default
 
 #### Defined in
 
-[animationInputMappers.ts:86](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L86)
+[animationInputMappers.ts:86](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/animationInputMappers.ts#L86)
 
 ___
 
@@ -83,7 +83,7 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:68](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L68)
+[animationInputMappers.ts:68](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/animationInputMappers.ts#L68)
 
 ___
 
@@ -109,4 +109,4 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L52)
+[animationInputMappers.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/animationInputMappers.ts#L52)

--- a/typedocs/animationInputMappers.md
+++ b/typedocs/animationInputMappers.md
@@ -34,7 +34,7 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:20](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/animationInputMappers.ts#L20)
+[animationInputMappers.ts:20](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L20)
 
 ___
 
@@ -58,7 +58,7 @@ See hooks.useSimpleTransitionState!default
 
 #### Defined in
 
-[animationInputMappers.ts:86](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/animationInputMappers.ts#L86)
+[animationInputMappers.ts:86](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L86)
 
 ___
 
@@ -83,7 +83,7 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:68](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/animationInputMappers.ts#L68)
+[animationInputMappers.ts:68](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L68)
 
 ___
 
@@ -109,4 +109,4 @@ The edits are:
 
 #### Defined in
 
-[animationInputMappers.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/animationInputMappers.ts#L52)
+[animationInputMappers.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/animationInputMappers.ts#L52)

--- a/typedocs/components.Animated.md
+++ b/typedocs/components.Animated.md
@@ -35,4 +35,4 @@ This component requires an AnimatedRef prop to manage the animations on the tag 
 
 #### Defined in
 
-[components/Animated.tsx:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/Animated.tsx#L38)
+[components/Animated.tsx:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/Animated.tsx#L38)

--- a/typedocs/components.Animated.md
+++ b/typedocs/components.Animated.md
@@ -35,4 +35,4 @@ This component requires an AnimatedRef prop to manage the animations on the tag 
 
 #### Defined in
 
-[components/Animated.tsx:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/Animated.tsx#L38)
+[components/Animated.tsx:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/Animated.tsx#L38)

--- a/typedocs/components.ControlledAnimated.md
+++ b/typedocs/components.ControlledAnimated.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[components/ControlledAnimated.tsx:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/ControlledAnimated.tsx#L7)
+[components/ControlledAnimated.tsx:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/ControlledAnimated.tsx#L7)
 
 ## Functions
 
@@ -62,4 +62,4 @@ This component is useful for synchronizing animations with other animated elemen
 
 #### Defined in
 
-[components/ControlledAnimated.tsx:70](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/ControlledAnimated.tsx#L70)
+[components/ControlledAnimated.tsx:70](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/ControlledAnimated.tsx#L70)

--- a/typedocs/components.ControlledAnimated.md
+++ b/typedocs/components.ControlledAnimated.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[components/ControlledAnimated.tsx:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/ControlledAnimated.tsx#L7)
+[components/ControlledAnimated.tsx:7](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/ControlledAnimated.tsx#L7)
 
 ## Functions
 
@@ -39,7 +39,7 @@ May accept a ref to forward to the HTML tag delegate, though there is no need to
 
 **`Link`**
 
-Animated)
+components.Animated)
 
 This component is useful for synchronizing animations with other animated elements
 
@@ -62,4 +62,4 @@ This component is useful for synchronizing animations with other animated elemen
 
 #### Defined in
 
-[components/ControlledAnimated.tsx:70](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/ControlledAnimated.tsx#L70)
+[components/ControlledAnimated.tsx:70](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/ControlledAnimated.tsx#L70)

--- a/typedocs/components.HoverAnimated.md
+++ b/typedocs/components.HoverAnimated.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[components/HoverAnimated.tsx:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/HoverAnimated.tsx#L6)
+[components/HoverAnimated.tsx:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/HoverAnimated.tsx#L6)
 
 ## Functions
 
@@ -33,7 +33,7 @@ May accept a ref to forward to the HTML tag delegate
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `A` | extends `string` = `never` | the additional animation names; default = never makes the default animation names exactly [HoverAnimations](../wiki/components.HoverAnimated#hoveranimations) |
+| `A` | extends `string` = `never` | the additional animation names; default = never makes the default animation names exactly [HoverAnimations](../wiki/components#hoveranimations) |
 | `T` | extends keyof `IntrinsicElements` = ``"div"`` | the HTML Tag delegate |
 
 #### Parameters
@@ -48,4 +48,4 @@ May accept a ref to forward to the HTML tag delegate
 
 #### Defined in
 
-[components/HoverAnimated.tsx:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/HoverAnimated.tsx#L29)
+[components/HoverAnimated.tsx:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/HoverAnimated.tsx#L29)

--- a/typedocs/components.HoverAnimated.md
+++ b/typedocs/components.HoverAnimated.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[components/HoverAnimated.tsx:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/HoverAnimated.tsx#L6)
+[components/HoverAnimated.tsx:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/HoverAnimated.tsx#L6)
 
 ## Functions
 
@@ -48,4 +48,4 @@ May accept a ref to forward to the HTML tag delegate
 
 #### Defined in
 
-[components/HoverAnimated.tsx:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/HoverAnimated.tsx#L29)
+[components/HoverAnimated.tsx:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/HoverAnimated.tsx#L29)

--- a/typedocs/components.common.NonHTMLAnimatedProps.md
+++ b/typedocs/components.common.NonHTMLAnimatedProps.md
@@ -28,7 +28,7 @@ The mapping of animationName A to an AnimationInput
 
 #### Defined in
 
-[components/common.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L52)
+[components/common.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L52)
 
 ___
 
@@ -40,4 +40,4 @@ The given tag that this Animated element delegates to
 
 #### Defined in
 
-[components/common.ts:47](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L47)
+[components/common.ts:47](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L47)

--- a/typedocs/components.common.NonHTMLAnimatedProps.md
+++ b/typedocs/components.common.NonHTMLAnimatedProps.md
@@ -28,7 +28,7 @@ The mapping of animationName A to an AnimationInput
 
 #### Defined in
 
-[components/common.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L52)
+[components/common.ts:52](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L52)
 
 ___
 
@@ -40,4 +40,4 @@ The given tag that this Animated element delegates to
 
 #### Defined in
 
-[components/common.ts:47](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L47)
+[components/common.ts:47](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L47)

--- a/typedocs/components.common.md
+++ b/typedocs/components.common.md
@@ -35,7 +35,7 @@ Standard Props for an animated element. Includes the HTMLAttributes for the give
 
 #### Defined in
 
-[components/common.ts:60](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L60)
+[components/common.ts:60](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L60)
 
 ___
 
@@ -48,7 +48,7 @@ Excludes tags that extend React.SVGProps
 
 #### Defined in
 
-[components/common.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L14)
+[components/common.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L14)
 
 ___
 
@@ -66,7 +66,7 @@ TagHTMLAttributes<"a"> is equivalent to React.AnchorHTMLAttributes<HTMLAnchorEle
 
 #### Defined in
 
-[components/common.ts:31](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L31)
+[components/common.ts:31](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L31)
 
 ___
 
@@ -84,7 +84,7 @@ TagHTMLElement<"a"> is equivalent to HTMLAnchorElement
 
 #### Defined in
 
-[components/common.ts:19](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L19)
+[components/common.ts:19](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L19)
 
 ## Functions
 
@@ -117,7 +117,7 @@ a new ref that manages both given refs as one
 
 #### Defined in
 
-[components/common.ts:83](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L83)
+[components/common.ts:83](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L83)
 
 ___
 
@@ -146,4 +146,4 @@ Helper to update a ref (either CallbackRef or RefObject) to the given next value
 
 #### Defined in
 
-[components/common.ts:66](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L66)
+[components/common.ts:66](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/components/common.ts#L66)

--- a/typedocs/components.common.md
+++ b/typedocs/components.common.md
@@ -35,7 +35,7 @@ Standard Props for an animated element. Includes the HTMLAttributes for the give
 
 #### Defined in
 
-[components/common.ts:60](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L60)
+[components/common.ts:60](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L60)
 
 ___
 
@@ -48,7 +48,7 @@ Excludes tags that extend React.SVGProps
 
 #### Defined in
 
-[components/common.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L14)
+[components/common.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L14)
 
 ___
 
@@ -66,7 +66,7 @@ TagHTMLAttributes<"a"> is equivalent to React.AnchorHTMLAttributes<HTMLAnchorEle
 
 #### Defined in
 
-[components/common.ts:31](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L31)
+[components/common.ts:31](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L31)
 
 ___
 
@@ -84,7 +84,7 @@ TagHTMLElement<"a"> is equivalent to HTMLAnchorElement
 
 #### Defined in
 
-[components/common.ts:19](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L19)
+[components/common.ts:19](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L19)
 
 ## Functions
 
@@ -117,7 +117,7 @@ a new ref that manages both given refs as one
 
 #### Defined in
 
-[components/common.ts:83](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L83)
+[components/common.ts:83](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L83)
 
 ___
 
@@ -146,4 +146,4 @@ Helper to update a ref (either CallbackRef or RefObject) to the given next value
 
 #### Defined in
 
-[components/common.ts:66](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/components/common.ts#L66)
+[components/common.ts:66](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/components/common.ts#L66)

--- a/typedocs/hooks.useAnimatedRef.AnimatedRef.md
+++ b/typedocs/hooks.useAnimatedRef.AnimatedRef.md
@@ -25,7 +25,7 @@ A React.Ref that declares itself as an AnimatedRef
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:9](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L9)
+[hooks/useAnimatedRef.ts:9](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedRef.ts#L9)
 
 ___
 
@@ -35,4 +35,4 @@ ___
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L10)
+[hooks/useAnimatedRef.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedRef.ts#L10)

--- a/typedocs/hooks.useAnimatedRef.AnimatedRef.md
+++ b/typedocs/hooks.useAnimatedRef.AnimatedRef.md
@@ -25,7 +25,7 @@ A React.Ref that declares itself as an AnimatedRef
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:9](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedRef.ts#L9)
+[hooks/useAnimatedRef.ts:9](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L9)
 
 ___
 
@@ -35,4 +35,4 @@ ___
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedRef.ts#L10)
+[hooks/useAnimatedRef.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L10)

--- a/typedocs/hooks.useAnimatedRef.md
+++ b/typedocs/hooks.useAnimatedRef.md
@@ -45,7 +45,7 @@ react Ref to be assigned to the Animated element
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedRef.ts#L34)
+[hooks/useAnimatedRef.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L34)
 
 ___
 
@@ -71,4 +71,4 @@ ref is AnimatedRef<E\>
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedRef.ts#L18)
+[hooks/useAnimatedRef.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L18)

--- a/typedocs/hooks.useAnimatedRef.md
+++ b/typedocs/hooks.useAnimatedRef.md
@@ -19,7 +19,7 @@
 
 Low-level hook to useRef that will animate the ref'd HTML element with the given currentAnimation name
 
-Expects the AnimationsByName<A> to be serialized as a JSON string in the data-animations attribute on the element - see ControlledAnimated!
+Expects the AnimationsByName<A> to be serialized as a JSON string in the data-animations attribute on the element - see [ControlledAnimated](../wiki/components#controlledanimated)
 
 Note: will interrupt and play a new animation if the animations stored at data-animations change and the Component using this hook is rerendered
 
@@ -45,7 +45,7 @@ react Ref to be assigned to the Animated element
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L34)
+[hooks/useAnimatedRef.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedRef.ts#L34)
 
 ___
 
@@ -71,4 +71,4 @@ ref is AnimatedRef<E\>
 
 #### Defined in
 
-[hooks/useAnimatedRef.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedRef.ts#L18)
+[hooks/useAnimatedRef.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedRef.ts#L18)

--- a/typedocs/hooks.useAnimatedToggle.md
+++ b/typedocs/hooks.useAnimatedToggle.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L11)
+[hooks/useAnimatedToggle.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedToggle.ts#L11)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L6)
+[hooks/useAnimatedToggle.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedToggle.ts#L6)
 
 ## Functions
 
@@ -66,4 +66,4 @@ Hook to create a boolean toggle state that animates when toggled
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L38)
+[hooks/useAnimatedToggle.ts:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedToggle.ts#L38)

--- a/typedocs/hooks.useAnimatedToggle.md
+++ b/typedocs/hooks.useAnimatedToggle.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedToggle.ts#L11)
+[hooks/useAnimatedToggle.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L11)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedToggle.ts#L6)
+[hooks/useAnimatedToggle.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L6)
 
 ## Functions
 
@@ -66,4 +66,4 @@ Hook to create a boolean toggle state that animates when toggled
 
 #### Defined in
 
-[hooks/useAnimatedToggle.ts:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedToggle.ts#L38)
+[hooks/useAnimatedToggle.ts:38](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedToggle.ts#L38)

--- a/typedocs/hooks.useAnimatedTransitionState.md
+++ b/typedocs/hooks.useAnimatedTransitionState.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedTransitionState.ts#L11)
+[hooks/useAnimatedTransitionState.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L11)
 
 ## Functions
 
@@ -52,7 +52,7 @@ Hook to useState that animates on transitioning states
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:37](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedTransitionState.ts#L37)
+[hooks/useAnimatedTransitionState.ts:37](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L37)
 
 ▸ **default**<`S`, `A`, `E`\>(`initialState`, `initialAnimation?`, `onAnimationEnd?`): [`AnimatedTransitionState`](../wiki/hooks.useAnimatedTransitionState#animatedtransitionstate)<`S`, `A`, `E`\>
 
@@ -80,7 +80,7 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:45](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedTransitionState.ts#L45)
+[hooks/useAnimatedTransitionState.ts:45](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L45)
 
 ▸ **default**<`S`, `A`, `E`\>(`initialState`, `initialAnimation?`, `onAnimationEnd?`): [`AnimatedTransitionState`](../wiki/hooks.useAnimatedTransitionState#animatedtransitionstate)<`S` \| `undefined`, `A`, `E`\>
 
@@ -110,4 +110,4 @@ Hook to useState that animates on transitioning states
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:50](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useAnimatedTransitionState.ts#L50)
+[hooks/useAnimatedTransitionState.ts:50](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L50)

--- a/typedocs/hooks.useAnimatedTransitionState.md
+++ b/typedocs/hooks.useAnimatedTransitionState.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L11)
+[hooks/useAnimatedTransitionState.ts:11](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedTransitionState.ts#L11)
 
 ## Functions
 
@@ -52,7 +52,7 @@ Hook to useState that animates on transitioning states
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:37](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L37)
+[hooks/useAnimatedTransitionState.ts:37](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedTransitionState.ts#L37)
 
 ▸ **default**<`S`, `A`, `E`\>(`initialState`, `initialAnimation?`, `onAnimationEnd?`): [`AnimatedTransitionState`](../wiki/hooks.useAnimatedTransitionState#animatedtransitionstate)<`S`, `A`, `E`\>
 
@@ -80,7 +80,7 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:45](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L45)
+[hooks/useAnimatedTransitionState.ts:45](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedTransitionState.ts#L45)
 
 ▸ **default**<`S`, `A`, `E`\>(`initialState`, `initialAnimation?`, `onAnimationEnd?`): [`AnimatedTransitionState`](../wiki/hooks.useAnimatedTransitionState#animatedtransitionstate)<`S` \| `undefined`, `A`, `E`\>
 
@@ -110,4 +110,4 @@ Hook to useState that animates on transitioning states
 
 #### Defined in
 
-[hooks/useAnimatedTransitionState.ts:50](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useAnimatedTransitionState.ts#L50)
+[hooks/useAnimatedTransitionState.ts:50](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useAnimatedTransitionState.ts#L50)

--- a/typedocs/hooks.useIsHovered.md
+++ b/typedocs/hooks.useIsHovered.md
@@ -28,4 +28,4 @@ readonly [`boolean`, `Ref`<`E`\>]
 
 #### Defined in
 
-[hooks/useIsHovered.ts:8](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useIsHovered.ts#L8)
+[hooks/useIsHovered.ts:8](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useIsHovered.ts#L8)

--- a/typedocs/hooks.useIsHovered.md
+++ b/typedocs/hooks.useIsHovered.md
@@ -28,4 +28,4 @@ readonly [`boolean`, `Ref`<`E`\>]
 
 #### Defined in
 
-[hooks/useIsHovered.ts:8](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useIsHovered.ts#L8)
+[hooks/useIsHovered.ts:8](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useIsHovered.ts#L8)

--- a/typedocs/hooks.useQueuedState.QueuedTransitionState.md
+++ b/typedocs/hooks.useQueuedState.QueuedTransitionState.md
@@ -29,7 +29,7 @@ Current state value
 
 #### Defined in
 
-[hooks/useQueuedState.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L10)
+[hooks/useQueuedState.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L10)
 
 ___
 
@@ -55,7 +55,7 @@ enqueue a state transition
 
 #### Defined in
 
-[hooks/useQueuedState.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L14)
+[hooks/useQueuedState.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L14)
 
 ___
 
@@ -75,7 +75,7 @@ process one queued transition
 
 #### Defined in
 
-[hooks/useQueuedState.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L18)
+[hooks/useQueuedState.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L18)
 
 ___
 
@@ -95,4 +95,4 @@ process all queued transitions
 
 #### Defined in
 
-[hooks/useQueuedState.ts:22](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L22)
+[hooks/useQueuedState.ts:22](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L22)

--- a/typedocs/hooks.useQueuedState.QueuedTransitionState.md
+++ b/typedocs/hooks.useQueuedState.QueuedTransitionState.md
@@ -29,7 +29,7 @@ Current state value
 
 #### Defined in
 
-[hooks/useQueuedState.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L10)
+[hooks/useQueuedState.ts:10](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L10)
 
 ___
 
@@ -55,7 +55,7 @@ enqueue a state transition
 
 #### Defined in
 
-[hooks/useQueuedState.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L14)
+[hooks/useQueuedState.ts:14](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L14)
 
 ___
 
@@ -75,7 +75,7 @@ process one queued transition
 
 #### Defined in
 
-[hooks/useQueuedState.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L18)
+[hooks/useQueuedState.ts:18](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L18)
 
 ___
 
@@ -95,4 +95,4 @@ process all queued transitions
 
 #### Defined in
 
-[hooks/useQueuedState.ts:22](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L22)
+[hooks/useQueuedState.ts:22](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L22)

--- a/typedocs/hooks.useQueuedState.md
+++ b/typedocs/hooks.useQueuedState.md
@@ -34,7 +34,7 @@ QueuedTransitionState
 
 #### Defined in
 
-[hooks/useQueuedState.ts:25](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L25)
+[hooks/useQueuedState.ts:25](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L25)
 
 ▸ **default**<`S`\>(`initialState`): [`QueuedTransitionState`](../wiki/hooks.useQueuedState.QueuedTransitionState)<`S`\>
 
@@ -58,4 +58,4 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useQueuedState.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useQueuedState.ts#L29)
+[hooks/useQueuedState.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L29)

--- a/typedocs/hooks.useQueuedState.md
+++ b/typedocs/hooks.useQueuedState.md
@@ -34,7 +34,7 @@ QueuedTransitionState
 
 #### Defined in
 
-[hooks/useQueuedState.ts:25](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L25)
+[hooks/useQueuedState.ts:25](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L25)
 
 ▸ **default**<`S`\>(`initialState`): [`QueuedTransitionState`](../wiki/hooks.useQueuedState.QueuedTransitionState)<`S`\>
 
@@ -58,4 +58,4 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useQueuedState.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useQueuedState.ts#L29)
+[hooks/useQueuedState.ts:29](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useQueuedState.ts#L29)

--- a/typedocs/hooks.useSimpleTransitionState.md
+++ b/typedocs/hooks.useSimpleTransitionState.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useSimpleTransitionState.ts#L6)
+[hooks/useSimpleTransitionState.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L6)
 
 ## Functions
 
@@ -51,7 +51,7 @@ This is a simplified version of useAnimatedTransitionState where only one animat
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useSimpleTransitionState.ts#L34)
+[hooks/useSimpleTransitionState.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L34)
 
 ▸ **default**<`S`, `E`\>(`initialState`, `initialTransitioning?`, `onTransitionEnd?`): [`SimpleTransitionState`](../wiki/hooks.useSimpleTransitionState#simpletransitionstate)<`S`, `E`\>
 
@@ -78,4 +78,4 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:39](https://github.com/tristanjohnson849/react-controlled-animations/blob/ea03579/src/hooks/useSimpleTransitionState.ts#L39)
+[hooks/useSimpleTransitionState.ts:39](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L39)

--- a/typedocs/hooks.useSimpleTransitionState.md
+++ b/typedocs/hooks.useSimpleTransitionState.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L6)
+[hooks/useSimpleTransitionState.ts:6](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useSimpleTransitionState.ts#L6)
 
 ## Functions
 
@@ -51,7 +51,7 @@ This is a simplified version of useAnimatedTransitionState where only one animat
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L34)
+[hooks/useSimpleTransitionState.ts:34](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useSimpleTransitionState.ts#L34)
 
 ▸ **default**<`S`, `E`\>(`initialState`, `initialTransitioning?`, `onTransitionEnd?`): [`SimpleTransitionState`](../wiki/hooks.useSimpleTransitionState#simpletransitionstate)<`S`, `E`\>
 
@@ -78,4 +78,4 @@ State is always a defined S if an initial state is provided
 
 #### Defined in
 
-[hooks/useSimpleTransitionState.ts:39](https://github.com/tristanjohnson849/react-controlled-animations/blob/35474ce/src/hooks/useSimpleTransitionState.ts#L39)
+[hooks/useSimpleTransitionState.ts:39](https://github.com/tristanjohnson849/react-controlled-animations/blob/5534f41/src/hooks/useSimpleTransitionState.ts#L39)


### PR DESCRIPTION
Finally figured out the right syntax for other modules