### PR TITLE
Changes shouldTransition for useSimpleTransitioningState to isAsync. …

### DIFF
--- a/src/hooks/useAnimatedRef.ts
+++ b/src/hooks/useAnimatedRef.ts
@@ -16,7 +16,7 @@ import { EnableAnimationContext } from './enableAnimationContext.js';
  * If given a new or null value while the previous aninmation is not finished(),
  * will commit the current style to the element and call onAnimationEnd
  * @param animations The mapping of animationName to AnimationInput
- * @param onAnimationEnd callback to be called when the animation is finished(), or if the animation is interrupted by a new currentAnimation
+ * @param onAnimationEnd callback to be called when the animation is finished(), or if the animation is interrupted by a new currentAnimation. Must be stable across renders.
  * @returns react Ref to be assigned to the Animated element
  */
 function useAnimatedRef<A extends string = string, E extends HTMLElement = HTMLElement>(

--- a/src/hooks/useSimpleTransitioningState.test.ts
+++ b/src/hooks/useSimpleTransitioningState.test.ts
@@ -98,7 +98,7 @@ test('defined state, initialTransitioning = false, endTransition => no changes',
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
         ([, , endTransition]) => endTransition,
-        ([state, , , currentTransition])=> {
+        ([state, , , currentTransition]) => {
             expect(state).toBe('Hello World');
             expect(currentTransition).toBe(false);
         }
@@ -112,7 +112,7 @@ test('defined state, startTransition isAsync = true, startTransition isAsync = f
             startTransition('Goodbye World', true);
             startTransition('Greetings World', false);
         },
-        ([state, , , currentTransition])=> {
+        ([state, , , currentTransition]) => {
             expect(state).toBe('Greetings World');
             expect(currentTransition).toBe(false);
         }
@@ -122,8 +122,10 @@ test('defined state, startTransition isAsync = true, startTransition isAsync = f
 test('defined state, startTransition isAsync = true, rerender, startTransition isAsync = false => state is second new value, currentTransition  = false', () => {
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
-        [([, startTransition]) => startTransition('Goodbye World', true),
-         ([, startTransition]) => startTransition('Greetings World', false)],
+        [
+            ([, startTransition]) => startTransition('Goodbye World', true),
+            ([, startTransition]) => startTransition('Greetings World', false),
+        ],
         ([state, , , currentTransition]) => {
             expect(state).toBe('Greetings World');
             expect(currentTransition).toBe(false);
@@ -131,12 +133,12 @@ test('defined state, startTransition isAsync = true, rerender, startTransition i
     );
 });
 
-test('defined state, startTransition isAsync = true x 2 => state unchaged, currentTransition = true', ()=> {
+test('defined state, startTransition isAsync = true x 2 => state unchaged, currentTransition = true', () => {
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
         ([, startTransition]) => {
-            startTransition('Goodbye World', true)
-            startTransition('Greetings World', true)
+            startTransition('Goodbye World', true);
+            startTransition('Greetings World', true);
         },
         ([state, , , currentTransition]) => {
             expect(state).toBe('Hello World');
@@ -148,8 +150,10 @@ test('defined state, startTransition isAsync = true x 2 => state unchaged, curre
 test('defined state, startTransition isAsync = true, re render, startTransition isAsync = true => state unchanged, currentTransition = true', () => {
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
-        [([, startTransition]) => startTransition('Goodbye World', true),
-         ([, startTransition]) => startTransition('Greetings World', true)],
+        [
+            ([, startTransition]) => startTransition('Goodbye World', true),
+            ([, startTransition]) => startTransition('Greetings World', true),
+        ],
         ([state, , , currentTransition]) => {
             expect(state).toBe('Hello World');
             expect(currentTransition).toBe(true);
@@ -160,11 +164,13 @@ test('defined state, startTransition isAsync = true, re render, startTransition 
 test('defined state, start Transition isAsync = true, start Transition isAsync = true, re render, endTransition => 2nd new state value, currentTransition = false', () => {
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
-        [([, startTransition]) => {
-            startTransition('Goodbye World', true);
-            startTransition('Greetings World', true);
-        },
-         ([, , endTransition]) => endTransition()],
+        [
+            ([, startTransition]) => {
+                startTransition('Goodbye World', true);
+                startTransition('Greetings World', true);
+            },
+            ([, , endTransition]) => endTransition(),
+        ],
         ([state, , , currentTransition]) => {
             expect(state).toBe('Greetings World');
             expect(currentTransition).toBe(false);
@@ -175,13 +181,14 @@ test('defined state, start Transition isAsync = true, start Transition isAsync =
 test('defined state, startTransition with action, isAsync = true, re render, startTransition with action, isAsync = true, re render, endTransition => startTransition actions occur in order, currentTransition = false', () => {
     actAndThen(
         renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
-        [([, startTransition]) => startTransition((prev) => prev + ' Hello', true),
-         ([, startTransition]) => startTransition((prev) => prev + ' World', true),
-        ([, , endTransition]) => endTransition()],
+        [
+            ([, startTransition]) => startTransition((prev) => prev + ' Hello', true),
+            ([, startTransition]) => startTransition((prev) => prev + ' World', true),
+            ([, , endTransition]) => endTransition(),
+        ],
         ([state, , , currentTransition]) => {
             expect(state).toBe('Hello World Hello World');
             expect(currentTransition).toBe(false);
         }
     );
 });
-

--- a/src/hooks/useSimpleTransitioningState.test.ts
+++ b/src/hooks/useSimpleTransitioningState.test.ts
@@ -1,0 +1,187 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { actAndThen } from '../testUtils';
+
+import useSimpleTransitioningState from './useSimpleTransitioningState';
+
+test('initial state undefined, initialTransitioning undefined => get undefined state, transition = null', () => {
+    const { result } = renderHook(() => useSimpleTransitioningState(undefined));
+    const [state, , , currentTransition] = result.current;
+
+    expect(state).toBeUndefined();
+    expect(currentTransition).toBe(false);
+});
+
+test('initial state defined, initialTransitioning undefined => get defined state, transition = null', () => {
+    const { result } = renderHook(() => useSimpleTransitioningState('Hello World'));
+    const [state, , , currentTransition] = result.current;
+
+    expect(state).toBe('Hello World');
+    expect(currentTransition).toBe(false);
+});
+
+test('initial state undefined, initialTransitioning true => get undefined state, transition = true', () => {
+    const { result } = renderHook(() => useSimpleTransitioningState(undefined, true));
+    const [state, , , currentTransition] = result.current;
+
+    expect(state).toBe(undefined);
+    expect(currentTransition).toBe(true);
+});
+
+test('initial state defined, initialTransitioning true = get defined state, transition = true', () => {
+    const { result } = renderHook(() => useSimpleTransitioningState('Hello World', true));
+    const [state, , , currentTransition] = result.current;
+
+    expect(state).toBe('Hello World');
+    expect(currentTransition).toBe(true);
+});
+
+test('initial state defined initialTransitioning = true, endTransition() => get defined state, transition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', true)).result,
+        ([, , endTransition]) => endTransition(),
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Hello World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('initial state defined, initialTransitioning = false, startTransition isAsync=false => new state and transition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, startTransition]) => startTransition('Goodbye World', false),
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Goodbye World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('initial state defined, initialTransitioning = false, startTransition isAsync = true => same defined state, transition = true', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, startTransition]) => startTransition('Goodbye World', true),
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Hello World');
+            expect(currentTransition).toBe(true);
+        }
+    );
+});
+
+test('initial state defined, startTransition with new state value isAsync = true, endTransition same render => new defined state, transition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, startTransition, endTransition]) => {
+            startTransition('Goodbye World', true);
+            endTransition();
+        },
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Goodbye World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('initial state defined, stratTransition with new state value isAsync = true, re render, endTransition => new state, transition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        [([, startTransition]) => startTransition('Goodbye World', true), ([, , endTransition]) => endTransition()],
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Goodbye World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('defined state, initialTransitioning = false, endTransition => no changes', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, , endTransition]) => endTransition,
+        ([state, , , currentTransition])=> {
+            expect(state).toBe('Hello World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('defined state, startTransition isAsync = true, startTransition isAsync = false => state is second new value, currentTransition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, startTransition]) => {
+            startTransition('Goodbye World', true);
+            startTransition('Greetings World', false);
+        },
+        ([state, , , currentTransition])=> {
+            expect(state).toBe('Greetings World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('defined state, startTransition isAsync = true, rerender, startTransition isAsync = false => state is second new value, currentTransition  = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        [([, startTransition]) => startTransition('Goodbye World', true),
+         ([, startTransition]) => startTransition('Greetings World', false)],
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Greetings World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('defined state, startTransition isAsync = true x 2 => state unchaged, currentTransition = true', ()=> {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        ([, startTransition]) => {
+            startTransition('Goodbye World', true)
+            startTransition('Greetings World', true)
+        },
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Hello World');
+            expect(currentTransition).toBe(true);
+        }
+    );
+});
+
+test('defined state, startTransition isAsync = true, re render, startTransition isAsync = true => state unchanged, currentTransition = true', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        [([, startTransition]) => startTransition('Goodbye World', true),
+         ([, startTransition]) => startTransition('Greetings World', true)],
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Hello World');
+            expect(currentTransition).toBe(true);
+        }
+    );
+});
+
+test('defined state, start Transition isAsync = true, start Transition isAsync = true, re render, endTransition => 2nd new state value, currentTransition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        [([, startTransition]) => {
+            startTransition('Goodbye World', true);
+            startTransition('Greetings World', true);
+        },
+         ([, , endTransition]) => endTransition()],
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Greetings World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+
+test('defined state, startTransition with action, isAsync = true, re render, startTransition with action, isAsync = true, re render, endTransition => startTransition actions occur in order, currentTransition = false', () => {
+    actAndThen(
+        renderHook(() => useSimpleTransitioningState('Hello World', false)).result,
+        [([, startTransition]) => startTransition((prev) => prev + ' Hello', true),
+         ([, startTransition]) => startTransition((prev) => prev + ' World', true),
+        ([, , endTransition]) => endTransition()],
+        ([state, , , currentTransition]) => {
+            expect(state).toBe('Hello World Hello World');
+            expect(currentTransition).toBe(false);
+        }
+    );
+});
+

--- a/src/hooks/useSimpleTransitioningState.ts
+++ b/src/hooks/useSimpleTransitioningState.ts
@@ -63,7 +63,7 @@ function useSimpleTransitioningState<S>(
 
     return [
         state,
-        (action, shouldTransition = true) => startTransition(action, shouldTransition ? 'transitioning' : null),
+        (action, isAsync = true) => startTransition(action, isAsync ? 'transitioning' : null),
         endTransition,
         currentTransition !== null,
     ];


### PR DESCRIPTION
Closes #17 

…Updates useAnimatedRef documentation. Implements tests for useSimpleTransitioningState.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
